### PR TITLE
feat: allow to rescan block devices before resizing

### DIFF
--- a/cmd/xelon-csi/main.go
+++ b/cmd/xelon-csi/main.go
@@ -15,14 +15,15 @@ import (
 
 func main() {
 	var (
-		apiURL       = flag.String("api-url", "https://vdc.xelon.ch/api/service/", "Xelon API URL")
-		endpoint     = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint")
-		logLevel     = flag.String("log-level", "info", "The log level for the CSI driver")
-		mode         = flag.String("mode", string(driver.AllMode), "The mode in which the CSI driver will be run (all, node, controller)")
-		metadataFile = flag.String("metadata-file", "/etc/init.d/metadata.json", "The path to the metadata file on Xelon devices")
-		token        = flag.String("token", "", "Xelon access token")
-		clientID     = flag.String("client-id", "", "Xelon client id for IP ranges")
-		version      = flag.Bool("version", false, "Print the version and exit.")
+		apiURL         = flag.String("api-url", "https://vdc.xelon.ch/api/service/", "Xelon API URL")
+		clientID       = flag.String("client-id", "", "Xelon client id for IP ranges")
+		endpoint       = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint")
+		logLevel       = flag.String("log-level", "info", "The log level for the CSI driver")
+		metadataFile   = flag.String("metadata-file", "/etc/init.d/metadata.json", "The path to the metadata file on Xelon devices")
+		mode           = flag.String("mode", string(driver.AllMode), "The mode in which the CSI driver will be run (all, node, controller)")
+		rescanOnResize = flag.Bool("rescan-on-resize", true, "Rescan block device and verify its size before expanding the filesystem (node mode)")
+		token          = flag.String("token", "", "Xelon access token")
+		version        = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
 
@@ -41,12 +42,13 @@ func main() {
 	logger := initializeLogging(*logLevel, *mode, *metadataFile)
 	d, err := driver.NewDriver(
 		&driver.Config{
-			BaseURL:      *apiURL,
-			ClientID:     *clientID,
-			Endpoint:     *endpoint,
-			Mode:         driver.Mode(*mode),
-			MetadataFile: *metadataFile,
-			Token:        *token,
+			BaseURL:        *apiURL,
+			ClientID:       *clientID,
+			Endpoint:       *endpoint,
+			Mode:           driver.Mode(*mode),
+			MetadataFile:   *metadataFile,
+			RescanOnResize: *rescanOnResize,
+			Token:          *token,
 		},
 		logger)
 	if err != nil {

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -464,8 +464,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 		return nil, status.Errorf(codes.Internal, "volume is not ready %v seconds", volumeStatusCheckRetries*volumeStatusCheckInterval)
 	}
 
-	log.WithField("new_volume_size", resizeBytes)
-	log.Info("volume was resized")
+	log.WithField("new_volume_size", resizeBytes).Info("volume was resized")
 
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         resizeBytes,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -29,12 +29,13 @@ type Mode string
 
 // Config is used to configure a new Driver
 type Config struct {
-	BaseURL      string
-	ClientID     string
-	Endpoint     string
-	Mode         Mode
-	MetadataFile string
-	Token        string
+	BaseURL        string
+	ClientID       string
+	Endpoint       string
+	Mode           Mode
+	MetadataFile   string
+	RescanOnResize bool
+	Token          string
 }
 
 // Driver implements the following CSI interfaces:

--- a/driver/helper/mounter.go
+++ b/driver/helper/mounter.go
@@ -34,6 +34,8 @@ type Mounter interface {
 	IsMounted(target string) (bool, error)
 	Mount(source, target string, options ...string) error
 	Unmount(target string) error
+
+	RescanSCSIDevices() error
 }
 
 type mounter struct {

--- a/driver/helper/scsi_devices.go
+++ b/driver/helper/scsi_devices.go
@@ -1,0 +1,123 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	scsiHostPath         = "/sys/class/scsi_host"
+	scsiHostScanPath     = "/sys/class/scsi_host/%s/scan"
+	scsiDevicePath       = "/sys/class/scsi_device"
+	scsiDeviceRescanPath = "/sys/class/scsi_device/%s/device/rescan"
+)
+
+func (m *mounter) RescanSCSIDevices() error {
+	log := m.log.WithFields(logrus.Fields{
+		"method": "rescan_scsi_devices",
+	})
+
+	// rescan hosts
+	scsiHosts, err := getSCSIHosts()
+	if err != nil {
+		log.Errorf("could not get scsi hosts, %v", err)
+		return err
+	}
+	for _, scsiHost := range scsiHosts {
+		scsiHostScanFile := fmt.Sprintf(scsiHostScanPath, scsiHost)
+		log.Debugf("rescan scsi host initiated for %v", scsiHostScanFile)
+
+		if !fileExist(scsiHostScanFile) {
+			log.Debugf("scsi host path %v does not exist", scsiHostScanFile)
+			continue
+		}
+
+		err = os.WriteFile(scsiHostScanFile, []byte("- - -"), 0644)
+		if err != nil {
+			log.Errorf("could not write to file %v: %v", scsiHostScanFile, err)
+		}
+	}
+
+	// rescan devices
+	scsiDevices, err := getSCSIDevices()
+	if err != nil {
+		log.Errorf("could not get scsi devices, %v", err)
+		return err
+	}
+	for _, scsiDevice := range scsiDevices {
+		scsiDeviceRescanFile := fmt.Sprintf(scsiDeviceRescanPath, scsiDevice)
+		log.Debugf("rescan scsi device initiated for %v", scsiDeviceRescanFile)
+
+		if !fileExist(scsiDeviceRescanFile) {
+			log.Debugf("scsi device path %v does not exist", scsiDeviceRescanFile)
+			continue
+		}
+
+		err = os.WriteFile(scsiDeviceRescanFile, []byte("1"), 0644)
+		if err != nil {
+			log.Errorf("could not write to file %v: %v", scsiDeviceRescanFile, err)
+		}
+	}
+
+	return nil
+}
+
+func getSCSIHosts() ([]string, error) {
+	exist := dirExist(scsiHostPath)
+	if !exist {
+		return nil, fmt.Errorf("directory %v does not exist", scsiHostPath)
+	}
+
+	files, err := os.ReadDir(scsiHostPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get list of scsi hosts, %v", err)
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	var scsiHosts []string
+	for _, f := range files {
+		scsiHosts = append(scsiHosts, f.Name())
+	}
+	return scsiHosts, nil
+}
+
+func getSCSIDevices() ([]string, error) {
+	exist := dirExist(scsiDevicePath)
+	if !exist {
+		return nil, fmt.Errorf("directory %v does not exist", scsiHostPath)
+	}
+
+	files, err := os.ReadDir(scsiDevicePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get list of scsi devices, %v", err)
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	var scsiDevices []string
+	for _, f := range files {
+		scsiDevices = append(scsiDevices, f.Name())
+	}
+	return scsiDevices, nil
+}
+
+func dirExist(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return info.IsDir()
+}
+
+func fileExist(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}


### PR DESCRIPTION
This PR solves the issue with re-scanning drives by resizing.
Per default this option is enabled and can be disabled if needed with `rescan-on-resize=false` parameter passed to *Node* service.