### PR TITLE
fix: call partprobe after rescanning scsi devices

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,6 +5,7 @@ RUN apk add --no-cache ca-certificates \
                        e2fsprogs \
                        e2fsprogs-extra \
                        findmnt \
+                       parted \
                        xfsprogs \
     && rm -rf /var/cache/apk/*
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -5,6 +5,7 @@ RUN apk add --no-cache ca-certificates \
                        e2fsprogs \
                        e2fsprogs-extra \
                        findmnt \
+                       parted \
                        xfsprogs \
     && rm -rf /var/cache/apk/*
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -83,7 +83,7 @@ func (d *Driver) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequ
 
 	if d.config.RescanOnResize {
 		if err := d.mounter.RescanSCSIDevices(); err != nil {
-			return nil, status.Errorf(codes.Internal, "error rescanning scsi devices %q: %v", req.VolumeId, err)
+			return nil, status.Errorf(codes.Internal, "NodeStageVolume error rescanning scsi devices %q: %v", req.VolumeId, err)
 		}
 	}
 
@@ -170,7 +170,7 @@ func (d *Driver) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolume
 
 	if d.config.RescanOnResize {
 		if err := d.mounter.RescanSCSIDevices(); err != nil {
-			return nil, status.Errorf(codes.Internal, "error rescanning scsi devices %q: %v", req.VolumeId, err)
+			return nil, status.Errorf(codes.Internal, "NodeUnstageVolume error rescanning scsi devices %q: %v", req.VolumeId, err)
 		}
 	}
 


### PR DESCRIPTION
Лernel 5.x will not inform about partition table changes after hot plug/unplug scsi devices from vmware. 'partprobe' will send partition table changes for every device mounted on the system.