### PR TITLE
feat: use build tags to ensure cross compilation

### DIFF
--- a/driver/helper/scsi_devices_linux.go
+++ b/driver/helper/scsi_devices_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package helper
 
 import (

--- a/driver/helper/scsi_devices_unsupported.go
+++ b/driver/helper/scsi_devices_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package helper
+
+import "github.com/sirupsen/logrus"
+
+func (m *mounter) RescanSCSIDevices() error {
+	m.log.WithFields(logrus.Fields{
+		"method": "rescan_scsi_devices",
+	}).Info("RescanSCSIDevices is not supported for this build")
+	return nil
+}


### PR DESCRIPTION
we can execute linux commands on linux systems only, using build tags (and GOOS suffixes) will ensure it