### PR TITLE
chore: update k8s registry images links

### DIFF
--- a/deploy/kubernetes/releases/xelon-csi-dev/driver.yml
+++ b/deploy/kubernetes/releases/xelon-csi-dev/driver.yml
@@ -219,7 +219,7 @@ spec:
               mountPath: /etc/init.d
               readOnly: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.0.2
           args:
             - "--csi-address=$(CSI_ADDRESS)"
             - "--default-fstype=ext4"
@@ -233,7 +233,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.1.0
           args:
             - "--csi-address=$(CSI_ADDRESS)"
             - "--v=5"
@@ -244,7 +244,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=30s"
@@ -314,7 +314,7 @@ spec:
               mountPath: /etc/init.d
               readOnly: true
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/releases/xelon-csi-v0.6.1/driver.yml
+++ b/deploy/kubernetes/releases/xelon-csi-v0.6.1/driver.yml
@@ -1,0 +1,354 @@
+#
+# This file is the release v0.6.1.
+#
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.xelon.ch
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: xelon-persistent-storage
+  namespace: kube-system
+provisioner: csi.xelon.ch
+allowVolumeExpansion: true
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: xelon-csi-controller-sa
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: xelon-csi-provisioner-role
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "create", "delete" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch", "update" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "storageclasses" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "list", "watch", "create", "update", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csinodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments" ]
+    verbs: [ "get", "list", "watch" ]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: xelon-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: xelon-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: xelon-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: xelon-csi-attacher-role
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "update", "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csinodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments" ]
+    verbs: [ "get", "list", "watch", "update", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments/status" ]
+    verbs: [ "patch" ]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: xelon-csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: xelon-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: xelon-csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: xelon-csi-resizer-role
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "update", "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims/status" ]
+    verbs: [ "update", "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "list", "watch", "create", "update", "patch" ]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: xelon-csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: xelon-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: xelon-csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: xelon-csi-node-sa
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: xelon-csi-node-driver-registrar-role
+  namespace: kube-system
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch" ]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: xelon-csi-node-driver-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: xelon-csi-node-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: xelon-csi-node-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+##############################################
+###########                       ############
+###########   Controller plugin   ############
+###########                       ############
+##############################################
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: xelon-csi-controller
+  namespace: kube-system
+spec:
+  serviceName: "xelon-csi"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: xelon-csi-controller
+  template:
+    metadata:
+      labels:
+        app: xelon-csi-controller
+        role: xelon-csi
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: xelon-csi-controller-sa
+      containers:
+        - name: xelon-csi-plugin
+          image: xelonag/xelon-csi:v0.6.0
+          args:
+            - "--api-url=$(XELON_API_URL)"
+            - "--client-id=$(XELON_API_CLIENT_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--mode=controller"
+            - "--token=$(XELON_API_TOKEN)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: XELON_API_URL
+              value: "INSERT_API_URL_HERE"
+            - name: XELON_API_CLIENT_ID
+              value: "INSERT_XELON_API_CLIENT_ID"
+            - name: XELON_API_TOKEN
+              value: "INSERT_TOKEN_HERE"
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: metadata-file
+              mountPath: /etc/init.d
+              readOnly: true
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.0.2
+          args:
+            - "--csi-address=$(CSI_ADDRESS)"
+            - "--default-fstype=ext4"
+            - "--retry-interval-start=5s"
+            - "--worker-threads=1"
+            - "--v=5"
+          env:
+            - name: CSI_ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.1.0
+          args:
+            - "--csi-address=$(CSI_ADDRESS)"
+            - "--v=5"
+          env:
+            - name: CSI_ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=30s"
+            - "--v=5"
+            - "--handle-volume-inuse-error=false"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: { }
+        - name: metadata-file
+          hostPath:
+            path: /etc/init.d
+
+---
+########################################
+###########                 ############
+###########   Node plugin   ############
+###########                 ############
+########################################
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: xelon-csi-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: xelon-csi-node
+  template:
+    metadata:
+      labels:
+        app: xelon-csi-node
+        role: xelon-csi-node
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccount: xelon-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: xelon-csi-plugin
+          image: xelonag/xelon-csi:v0.6.0
+          args:
+            - "--mode=node"
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            privileged: true
+            capabilities:
+              add: [ "SYS_ADMIN" ]
+            allowPrivilegeEscalation: true
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: device-dir
+              mountPath: /dev
+            - name: metadata-file
+              mountPath: /etc/init.d
+              readOnly: true
+        - name: csi-node-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.xelon.ch/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi/
+            - name: registration-dir
+              mountPath: /registration/
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.xelon.ch
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+        - name: metadata-file
+          hostPath:
+            path: /etc/init.d


### PR DESCRIPTION
This PR updates CSI image links with the new image registry: https://kubernetes.io/blog/2023/03/10/image-registry-redirect/

Fixes #10.