### PR TITLE
feat: read metadata from envvars with fallback

### DIFF
--- a/driver/helper/metadata.go
+++ b/driver/helper/metadata.go
@@ -14,6 +14,29 @@ type deviceInfo struct {
 }
 
 func getDeviceInfo(metadataFile string) (*deviceInfo, error) {
+	// reading device info from envvars is the new approach,
+	// so try to use it and fallback if no envvar is defined
+	deviceInfo := getDeviceInfoFromEnv()
+	if deviceInfo.Metadata.LocalVMID == "" {
+		return getDeviceInfoFromFile(metadataFile)
+	}
+	return deviceInfo, nil
+}
+
+func getDeviceInfoFromEnv() *deviceInfo {
+	cloudID := os.Getenv("XELON_CLOUD_ID")
+	localVMID := os.Getenv("XELON_LOCAL_VM_ID")
+	hostname := os.Getenv("XELON_VM_HOSTNAME")
+
+	deviceInfoFromEnv := new(deviceInfo)
+	deviceInfoFromEnv.Metadata.CloudID = cloudID
+	deviceInfoFromEnv.Metadata.LocalVMID = localVMID
+	deviceInfoFromEnv.Metadata.Hostname = hostname
+
+	return deviceInfoFromEnv
+}
+
+func getDeviceInfoFromFile(metadataFile string) (*deviceInfo, error) {
 	f, err := os.Open(metadataFile)
 	if err != nil {
 		return nil, err

--- a/driver/helper/metadata_test.go
+++ b/driver/helper/metadata_test.go
@@ -1,0 +1,61 @@
+package helper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDeviceInfoFromEnv(t *testing.T) {
+	setUpEnvVars()
+	_ = os.Setenv("XELON_CLOUD_ID", "5")
+	_ = os.Setenv("XELON_LOCAL_VM_ID", "abcd1234")
+	_ = os.Setenv("XELON_VM_HOSTNAME", "test.local")
+
+	deviceInfo := getDeviceInfoFromEnv()
+
+	assert.Equal(t, "5", deviceInfo.Metadata.CloudID)
+	assert.Equal(t, "abcd1234", deviceInfo.Metadata.LocalVMID)
+	assert.Equal(t, "test.local", deviceInfo.Metadata.Hostname)
+}
+
+func TestGetDeviceInfoFromFile_valid(t *testing.T) {
+	setUpEnvVars()
+	metadataFile := filepath.Join("testdata", "valid-metadata.json")
+
+	deviceInfo, err := getDeviceInfoFromFile(metadataFile)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "1", deviceInfo.Metadata.CloudID)
+	assert.Equal(t, "abcd1234", deviceInfo.Metadata.LocalVMID)
+	assert.Equal(t, "test.local", deviceInfo.Metadata.Hostname)
+}
+
+func TestGetDeviceInfoFromFile_invalid(t *testing.T) {
+	setUpEnvVars()
+	metadataFile := filepath.Join("testdata", "invalid-metadata.json")
+
+	_, err := getDeviceInfoFromFile(metadataFile)
+
+	assert.Error(t, err)
+}
+
+func TestGetDeviceInfo(t *testing.T) {
+	setUpEnvVars()
+	// XELON_LOCAL_VM_ID is not defined, fallback to file values
+	_ = os.Setenv("XELON_CLOUD_ID", "5")
+	metadataFile := filepath.Join("testdata", "valid-metadata.json")
+
+	deviceInfo, err := getDeviceInfo(metadataFile)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "1", deviceInfo.Metadata.CloudID)
+}
+
+func setUpEnvVars() {
+	_ = os.Unsetenv("XELON_CLOUD_ID")
+	_ = os.Unsetenv("XELON_LOCAL_VM_ID")
+	_ = os.Unsetenv("XELON_VM_HOSTNAME")
+}

--- a/driver/helper/testdata/invalid-metadata.json
+++ b/driver/helper/testdata/invalid-metadata.json
@@ -1,0 +1,2 @@
+{
+	"invalid-json-format": "some-value"

--- a/driver/helper/testdata/valid-metadata.json
+++ b/driver/helper/testdata/valid-metadata.json
@@ -1,0 +1,7 @@
+{
+	"metadata": {
+		"cloudId": "1",
+		"local_id": "abcd1234",
+		"hostname": "test.local"
+	}
+}


### PR DESCRIPTION
This PR adds a feature to read metadata information (cloudID, localVMID and hostname) from environment variables.
In case envvars are not defined, the "old" mechanism to read metadata from file will be used as fallback.