### PR TITLE
fix: use correct context for build-docker-dev goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build:
 .PHONE: build-docker-dev
 build-docker-dev: build
 	@echo "==> Building docker image $(IMAGE_NAME)..."
-	@docker build --build-arg VERSION=$(VERSION) --tag $(IMAGE_NAME):dev --file Dockerfile build
+	@docker build --build-arg VERSION=$(VERSION) --tag $(IMAGE_NAME):dev --file Dockerfile .
 
 
 ## release-docker-dev: Release development docker image.


### PR DESCRIPTION
The PR fixes failing build for `build-docker-dev` goal. The context is the current folder `.` not `build`.