### PR TITLE
chore: add helm integration

### DIFF
--- a/charts/xelon-csi/.helmignore
+++ b/charts/xelon-csi/.helmignore
@@ -1,35 +1,24 @@
 #################################
-# Compiled sources              #
+# Git & GitHub files             #
 #################################
-build/
-
-#################################
-# Helm files                  #
-#################################
-/charts/xelon-csi/values-dev.yaml
-
-#################################
-# Golang files                  #
-#################################
-/tools/bin/
-.bin/
-*.exe
-*.dll
-*.so
-*.dylib
-*.test
-*.out
+.git/
+.github/
+.gitignore
 
 #################################
 # IDE generated files           #
 #################################
 .idea/
+.vscode/
+.project
 *.iml
 
 #################################
 # Logs and temp files           #
 #################################
+*.bak
 *.log
+*.orig
 *.swp
 *~
 

--- a/charts/xelon-csi/Chart.yaml
+++ b/charts/xelon-csi/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: xelon-csi
+version: 0.1.0
+description: A Helm Chart for the CSI Driver on Xelon HQ
+type: application
+
+appVersion: "1.0.0"

--- a/charts/xelon-csi/templates/NOTES.txt
+++ b/charts/xelon-csi/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Xelon CSI Driver {{ .Chart.AppVersion }} was deployed in namespace {{ .Release.Namespace }}.
+
+To verify that xelon-csi has successfully started, run:
+    kubectl -n kube-system logs --selector app=xelon-csi-controller
+    kubectl -n kube-system logs --selector app=xelon-csi-node

--- a/charts/xelon-csi/templates/_helpers.tpl
+++ b/charts/xelon-csi/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "xelon-csi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "xelon-csi.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "xelon-csi.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "xelon-csi.labels" -}}
+helm.sh/chart: {{ include "xelon-csi.chart" . }}
+{{ include "xelon-csi.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "xelon-csi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "xelon-csi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/xelon-csi/templates/controller.yaml
+++ b/charts/xelon-csi/templates/controller.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: xelon-csi-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: xelon-csi-controller
+  serviceName: "xelon-csi"
+  replicas: {{ .Values.controller.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: xelon-csi-controller
+        role: xelon-csi
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
+      containers:
+        - name: xelon-csi-plugin
+          image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          args:
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--xelon-base-url=$(XELON_BASE_URL)"
+            - "--xelon-client-id=$(XELON_CLIENT_ID)"
+            - "--xelon-cloud-id=$(XELON_CLOUD_ID)"
+            - "--xelon-token=$(XELON_TOKEN)"
+            - "--logging-format={{ .Values.controller.loggingFormat }}"
+            - "--mode=controller"
+            - "--v={{ .Values.controller.logLevel }}"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: XELON_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: xelon-api-credentials
+                  key: baseUrl
+            - name: XELON_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: xelon-api-credentials
+                  key: clientId
+            - name: XELON_CLOUD_ID
+              valueFrom:
+                secretKeyRef:
+                  name: xelon-api-credentials
+                  key: cloudId
+            - name: XELON_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: xelon-api-credentials
+                  key: token
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-provisioner
+          image: {{ .Values.sidecars.provisioner.image.repository }}:{{ .Values.sidecars.provisioner.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.provisioner.image.pullPolicy }}
+          args:
+            - "--csi-address=$(CSI_ADDRESS)"
+            - "--default-fstype=ext4"
+            - "--extra-create-metadata"
+            - "--retry-interval-start=5s"
+            - "--timeout=120s"
+            - "--v={{ .Values.sidecars.provisioner.logLevel }}"
+            - "--worker-threads=1"
+          env:
+            - name: CSI_ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-attacher
+          image: {{ .Values.sidecars.attacher.image.repository }}:{{ .Values.sidecars.attacher.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.attacher.image.pullPolicy }}
+          args:
+            - "--csi-address=$(CSI_ADDRESS)"
+            - "--timeout=60s"
+            - "--v={{ .Values.sidecars.attacher.logLevel }}"
+            - "--worker-threads=1"
+          env:
+            - name: CSI_ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-resizer
+          image: {{ .Values.sidecars.resizer.image.repository }}:{{ .Values.sidecars.resizer.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.resizer.image.pullPolicy }}
+          args:
+            - "--csi-address=$(CSI_ADDRESS)"
+            - "--handle-volume-inuse-error=false"
+            - "--timeout=60s"
+            - "--v={{ .Values.sidecars.resizer.logLevel }}"
+          env:
+            - name: CSI_ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/charts/xelon-csi/templates/csidriver.yaml
+++ b/charts/xelon-csi/templates/csidriver.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.xelon.ch
+spec:
+  attachRequired: true
+  podInfoOnMount: false

--- a/charts/xelon-csi/templates/node.yaml
+++ b/charts/xelon-csi/templates/node.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: xelon-csi-node
+  namespace: {{ .Release.Namespace }}
+spec:
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: xelon-csi-node
+  template:
+    metadata:
+      labels:
+        app: xelon-csi-node
+        role: xelon-csi-node
+    spec:
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      serviceAccountName: {{ .Values.node.serviceAccount.name }}
+      containers:
+        - name: xelon-csi-plugin
+          image: {{ .Values.node.image.repository }}:{{ .Values.node.image.tag }}
+          imagePullPolicy: {{ .Values.node.image.pullPolicy }}
+          args:
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--logging-format={{ .Values.node.loggingFormat }}"
+            - "--mode=node"
+            - "--rescan-on-resize=true"
+            - "--v={{ .Values.node.logLevel }}"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: device-dir
+              mountPath: /dev
+        - name: csi-node-driver-registrar
+          image: {{ .Values.sidecars.nodeDriverRegistrar.image.repository }}:{{ .Values.sidecars.nodeDriverRegistrar.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.nodeDriverRegistrar.image.pullPolicy }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            - "--v={{ .Values.sidecars.nodeDriverRegistrar.logLevel }}"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.xelon.ch/csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.xelon.ch/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev

--- a/charts/xelon-csi/templates/rbac-controller-attacher.yaml
+++ b/charts/xelon-csi/templates/rbac-controller-attacher.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: xelon-csi-attacher-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xelon-csi-attacher-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: xelon-csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/xelon-csi/templates/rbac-controller-provisioner.yaml
+++ b/charts/xelon-csi/templates/rbac-controller-provisioner.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: xelon-csi-provisioner-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xelon-csi-provisioner-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: xelon-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/xelon-csi/templates/rbac-controller-resizer.yaml
+++ b/charts/xelon-csi/templates/rbac-controller-resizer.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: xelon-csi-resizer-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xelon-csi-resizer-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: xelon-csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/xelon-csi/templates/rbac-node-registrar.yaml
+++ b/charts/xelon-csi/templates/rbac-node-registrar.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: xelon-csi-node-driver-registrar-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xelon-csi-node-driver-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.node.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: xelon-csi-node-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/xelon-csi/templates/secret.yaml
+++ b/charts/xelon-csi/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.xelonSecret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: xelon-api-credentials
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  baseUrl: {{ .Values.xelonSecret.baseUrl | quote }}
+  clientId: {{ .Values.xelonSecret.clientId | quote }}
+  cloudId: {{ .Values.xelonSecret.cloudId | quote }}
+  kubernetesClusterId: {{ .Values.xelonSecret.kubernetesClusterId | quote }}
+  token: {{ .Values.xelonSecret.token | quote }}
+{{- end -}}

--- a/charts/xelon-csi/templates/serviceaccount-controller.yaml
+++ b/charts/xelon-csi/templates/serviceaccount-controller.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.controller.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/xelon-csi/templates/serviceaccount-node.yaml
+++ b/charts/xelon-csi/templates/serviceaccount-node.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.node.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.node.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.node.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/xelon-csi/templates/storageclass.yaml
+++ b/charts/xelon-csi/templates/storageclass.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: xelon-persistent-storage
+  namespace: {{ .Release.Namespace }}
+provisioner: csi.xelon.ch
+allowVolumeExpansion: true

--- a/charts/xelon-csi/values.yaml
+++ b/charts/xelon-csi/values.yaml
@@ -1,0 +1,61 @@
+nameOverride: ""
+fullnameOverride: ""
+
+controller:
+  image:
+    repository: xelonag/xelon-csi
+    tag: "dev"
+    pullPolicy: Always
+  loggingFormat: text
+  logLevel: 2
+  replicaCount: 1
+  serviceAccount:
+    create: true
+    name: "xelon-csi-controller-sa"
+    annotations: {}
+
+node:
+  image:
+    repository: xelonag/xelon-csi
+    tag: "dev"
+    pullPolicy: Always
+  loggingFormat: text
+  logLevel: 2
+  serviceAccount:
+    create: true
+    name: "xelon-csi-node-sa"
+    annotations: {}
+
+sidecars:
+  attacher:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-attacher
+      tag: "v4.4.0"
+      pullPolicy: IfNotPresent
+    logLevel: 5
+  nodeDriverRegistrar:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+      tag: "v2.9.0"
+      pullPolicy: IfNotPresent
+    logLevel: 5
+  provisioner:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-provisioner
+      tag: "v3.6.0"
+      pullPolicy: IfNotPresent
+    logLevel: 5
+  resizer:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-resizer
+      tag: "v1.9.0"
+      pullPolicy: IfNotPresent
+    logLevel: 5
+
+xelonSecret:
+  create: false
+  baseUrl: "https://hq.xelon.ch/api/service/"
+  clientId: ""
+  cloudId: ""
+  kubernetesClusterId: ""
+  token: ""

--- a/deploy/xelon-csi.yaml
+++ b/deploy/xelon-csi.yaml
@@ -229,7 +229,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-            - "--v=2"
+            - "--v=5"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
This PR adds Helm integration (to be consistent with `xelon-cloud-controller-manager`).