### PR TITLE
fix: inject version info via ldflags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,6 @@ build/
 deploy/
 test/
 tools/
+Makefile
 README.md
 .golangci.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # syntax=docker/dockerfile:1
 FROM golang:1.22 AS builder
 
+ARG GIT_COMMIT
+ARG GIT_TREE_STATE
+ARG SOURCE_DATE_EPOCH
+ARG VERSION
+
 ENV CGO_ENABLED=0
 
 # copy manifest files only to cache layer with dependencies
@@ -12,7 +17,13 @@ COPY cmd/ cmd/
 COPY internal/ internal/
 
 # build
-RUN go build -o xelon-csi -ldflags="-s -w" -trimpath cmd/xelon-csi/main.go
+RUN go build -trimpath \
+    -ldflags="-s -w \
+    -X github.com/Xelon-AG/xelon-csi/internal/driver.gitCommit=${GIT_COMMIT:-none} \
+    -X github.com/Xelon-AG/xelon-csi/internal/driver.gitTreeState=${GIT_TREE_STATE:-none} \
+    -X github.com/Xelon-AG/xelon-csi/internal/driver.sourceDateEpoch=${SOURCE_DATE_EPOCH:-0} \
+    -X github.com/Xelon-AG/xelon-csi/internal/driver.version=${VERSION:-local}" \
+    -o xelon-csi cmd/xelon-csi/main.go
 
 
 

--- a/internal/driver/cloud/xelon_client.go
+++ b/internal/driver/cloud/xelon_client.go
@@ -8,7 +8,7 @@ import (
 
 type ClientOptions xelon.ClientOption
 
-func NewXelonClient(token, clientID, baseURL string) (*xelon.Client, error) {
+func NewXelonClient(token, clientID, baseURL, userAgent string) (*xelon.Client, error) {
 	if token == "" {
 		return nil, errors.New("token must not be empty")
 	}
@@ -22,7 +22,7 @@ func NewXelonClient(token, clientID, baseURL string) (*xelon.Client, error) {
 	var opts []xelon.ClientOption
 	opts = append(opts, xelon.WithBaseURL(baseURL))
 	opts = append(opts, xelon.WithClientID(clientID))
-	opts = append(opts, xelon.WithUserAgent("xelon-csi"))
+	opts = append(opts, xelon.WithUserAgent(userAgent))
 
 	client := xelon.NewClient(token, opts...)
 	return client, nil

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -61,7 +61,7 @@ type controllerService struct {
 func newControllerService(ctx context.Context, opts *Options) (*controllerService, error) {
 	klog.V(2).InfoS("Initialize controller service")
 
-	xelonClient, err := cloud.NewXelonClient(opts.XelonToken, opts.XelonClientID, opts.XelonBaseURL)
+	xelonClient, err := cloud.NewXelonClient(opts.XelonToken, opts.XelonClientID, opts.XelonBaseURL, UserAgent())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -49,7 +49,7 @@ type Driver struct {
 }
 
 func NewDriver(ctx context.Context, opts *Options) (*Driver, error) {
-	klog.InfoS("Driver information", "driver", DefaultDriverName, "version", "dev")
+	klog.InfoS("Driver information", "driver", DefaultDriverName, "version_info", GetVersionInfo())
 
 	d := &Driver{
 		endpoint: opts.Endpoint,

--- a/internal/driver/identity.go
+++ b/internal/driver/identity.go
@@ -12,7 +12,7 @@ func (d *Driver) GetPluginInfo(_ context.Context, req *csi.GetPluginInfoRequest)
 
 	return &csi.GetPluginInfoResponse{
 		Name:          DefaultDriverName,
-		VendorVersion: "wip",
+		VendorVersion: GetVersion(),
 	}, nil
 }
 

--- a/internal/driver/version.go
+++ b/internal/driver/version.go
@@ -1,0 +1,40 @@
+package driver
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// These are set during build time via -ldflags
+var (
+	gitCommit       = "none"
+	gitTreeState    = "none"
+	sourceDateEpoch = "0"
+	version         = "dev"
+)
+
+type VersionInfo struct {
+	GitCommit       string `json:"git_commit,omitempty"`
+	GitTreeState    string `json:"git_tree_state,omitempty"`
+	GoVersion       string `json:"go_version,omitempty"`
+	SourceDateEpoch string `json:"source_data_epoch,omitempty"`
+	Version         string `json:"version,omitempty"`
+}
+
+func GetVersion() string {
+	return version
+}
+
+func GetVersionInfo() VersionInfo {
+	return VersionInfo{
+		GitCommit:       gitCommit,
+		GitTreeState:    gitTreeState,
+		GoVersion:       runtime.Version(),
+		SourceDateEpoch: sourceDateEpoch,
+		Version:         version,
+	}
+}
+
+func UserAgent() string {
+	return fmt.Sprintf("xelon-csi/%s", version)
+}


### PR DESCRIPTION
This PR restores functionality with injecting version info via ldflags.

Use https://reproducible-builds.org/docs/source-date-epoch/ instead of build date to get consistent and reproducible docker images.