### PR TITLE
chore(gh-actions): build driver before run linter and tests

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,53 +1,31 @@
 project_name: xelon-csi
 
-archives:
-  - files:
-      - LICENSE
-      - README.md
-    format: zip
-    name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}'
-    rlcp: true
-
 before:
   hooks:
     - go mod tidy
 
 builds:
-  - binary: '{{ .ProjectName }}'
-    flags:
-      - -trimpath
-    goarch:
-      - amd64
-    goos:
-      - linux
-    ldflags:
-      - -s -w
-      - -X github.com/Xelon-AG/xelon-csi/driver.driverVersion={{ .Version }}
-      - -X github.com/Xelon-AG/xelon-csi/driver.gitCommit={{ .Commit }}
-      - -X github.com/Xelon-AG/xelon-csi/driver.gitTreeState=clean
-      - -X github.com/Xelon-AG/xelon-csi/driver.buildDate={{ .Date }}
-    main: cmd/xelon-csi/main.go
-    mod_timestamp: '{{ .CommitTimestamp }}'
+  - skip: true
 
 changelog:
-  skip: true
-
-checksum:
-  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
-  algorithm: sha256
-
-dist: build
-
-dockers:
-  - dockerfile: Dockerfile
-    goarch: amd64
-    goos: linux
-    image_templates:
-      - "xelonag/xelon-csi:latest"
-      - "xelonag/xelon-csi:{{ .Tag }}"
-
-env:
-  - CGO_ENABLED=0
+  sort: asc
+  groups:
+    - title: "Features"
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: "Others"
+      order: 999
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^Merge pull request"
+      - "^Release"
 
 release:
-  draft: false
+  github:
+    owner: Xelon-AG
+    name: xelon-csi

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -11,15 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: "go.mod"
-          cache: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -28,4 +22,4 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Release development Docker image
-        run: make build release-docker-dev
+        run: make release-docker-dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,15 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: "go.mod"
-          cache: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -29,10 +23,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+      - name: Release production Docker images
+        run: make release-docker
+
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --config .github/goreleaser.yaml --clean
+          args: release -f .github/goreleaser.yaml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,14 @@ jobs:
       - name: Release production Docker images
         run: make release-docker
 
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: xelonag/xelon-csi
+          short-description: "Xelon Persistent Storage CSI Driver"
+
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on:
       - "CHANGELOG.md"
       - "README.md"
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - "CHANGELOG.md"
       - "README.md"
@@ -14,30 +14,41 @@ permissions:
   contents: read
 
 jobs:
-  unit-tests:
-    name: unit tests
+  build:
+    name: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
 
-      - name: Set up cache
-        uses: actions/cache@v3
+      - name: Build driver
+        run: make build
+
+  unit-tests:
+    name: unit tests
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum', 'tools/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: "go.mod"
+
+      - name: Install tools
+        run: make tools
 
       - name: Lint source code
-        run: make tools lint
+        run: make lint
 
       - name: Run unit tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ test:
 .PHONE: build
 build:
 	@echo "==> Building binary..."
-	@echo "    running go build"
-	@CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(PROJECT_NAME) cmd/xelon-csi/main.go
+	@echo "    running go build for GOOS=linux GOARCH=amd64"
+	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(PROJECT_NAME) cmd/xelon-csi/main.go
 
 
 ## build-docker: Build docker image with included binary.


### PR DESCRIPTION
This PR refactors GitHub actions (tests and release) to use latest actions and optimize linting and test runs.